### PR TITLE
wpe_view_backend_create: fail early if backend can not be loaded

### DIFF
--- a/src/view-backend.c
+++ b/src/view-backend.c
@@ -36,6 +36,9 @@ struct wpe_view_backend*
 wpe_view_backend_create()
 {
     struct wpe_view_backend_interface* backend_interface = wpe_load_object("_wpe_view_backend_interface");
+    if (!backend_interface)
+        return 0;
+
     return wpe_view_backend_create_with_backend_interface(backend_interface, 0);
 }
 


### PR DESCRIPTION
This allows WPEView to abort cleanly if no backend can be created.