### PR TITLE
Properly find EGL and pass any flag defined on the EGL pkgconfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -D_POSIX_SOURCE")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
+find_package(EGL REQUIRED)
+
+add_definitions(${EGL_DEFINITIONS})
 
 if(WPE_BACKEND)
   add_definitions(-DWPE_BACKEND=\"${WPE_BACKEND}\")
@@ -10,6 +15,7 @@ endif()
 set(WPE_INCLUDE_DIRECTORIES
     "include"
     "src"
+    ${EGL_INCLUDE_DIRS}
 )
 
 set(WPE_LIBRARIES

--- a/cmake/FindEGL.cmake
+++ b/cmake/FindEGL.cmake
@@ -1,0 +1,54 @@
+# - Try to Find EGL
+# Once done, this will define
+#
+#  EGL_FOUND - system has EGL installed.
+#  EGL_INCLUDE_DIRS - directories which contain the EGL headers.
+#  EGL_LIBRARIES - libraries required to link against EGL.
+#  EGL_DEFINITIONS - Compiler switches required for using EGL.
+#
+# Copyright (C) 2012 Intel Corporation. All rights reserved.
+# Copyright (C) 2017 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND ITS CONTRIBUTORS ``AS
+# IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR ITS
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+find_package(PkgConfig)
+
+pkg_check_modules(PC_EGL egl)
+
+if (PC_EGL_FOUND)
+    set(EGL_DEFINITIONS ${PC_EGL_CFLAGS_OTHER})
+endif ()
+
+find_path(EGL_INCLUDE_DIRS NAMES EGL/eglplatform.h
+    HINTS ${PC_EGL_INCLUDEDIR} ${PC_EGL_INCLUDE_DIRS}
+)
+
+set(EGL_NAMES ${EGL_NAMES} egl EGL)
+find_library(EGL_LIBRARIES NAMES ${EGL_NAMES}
+    HINTS ${PC_EGL_LIBDIR} ${PC_EGL_LIBRARY_DIRS}
+)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(EGL DEFAULT_MSG EGL_INCLUDE_DIRS EGL_LIBRARIES)
+
+mark_as_advanced(EGL_INCLUDE_DIRS EGL_LIBRARIES)


### PR DESCRIPTION
WPEBackend depends on EGL (it includes eglplatform.h and calls to different EGL APIs) but its not declaring that dependency to CMake.

This is usually not a problem: even if CMake is not aware of this, by including the header things will go fine.

But, when using the EGL libraries from Vivante, the compiler needs also to define the following cflags 
```
-DLINUX -DEGL_API_FB -DWL_EGL_PLATFORM
```
Otherwise the build will fail.

The Vivante EGL libraries properly define this on their egl.pc file.
We need to inspect this info via pkg-config and pass it to the build.