### PR TITLE
Use the libtool versioning scheme for libWPEBackend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,23 @@
 cmake_minimum_required(VERSION 3.0)
 cmake_policy(VERSION 3.0)
 
-project(wpebackend VERSION 0.2.0)
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(VersioningUtils)
 
+SET_PROJECT_VERSION(1 0 0)
 set(WPE_API_VERSION "0.1")
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+# Before making a release, the LT_VERSION string should be modified.
+# The string is of the form C:R:A.
+# - If interfaces have been changed or added, but binary compatibility has
+#   been preserved, change to C+1:0:A+1
+# - If binary compatibility has been broken (eg removed or changed interfaces)
+#   change to C+1:0:0
+# - If the interface is the same as the previous version, change to C:R+1:A
+CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE(LIBWPEBACKEND 1 0 0)
+
+project(wpebackend VERSION "${PROJECT_VERSION}")
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -D_POSIX_SOURCE")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
@@ -69,8 +81,8 @@ target_link_libraries(WPEBackend ${WPE_LIBRARIES})
 
 set_target_properties(WPEBackend PROPERTIES
   OUTPUT_NAME WPEBackend-${WPE_API_VERSION}
-  VERSION ${PROJECT_VERSION}
-  SOVERSION ${PROJECT_VERSION_MAJOR}
+  VERSION ${LIBWPEBACKEND_VERSION}
+  SOVERSION ${LIBWPEBACKEND_VERSION_MAJOR}
 )
 
 install(TARGETS WPEBackend

--- a/cmake/VersioningUtils.cmake
+++ b/cmake/VersioningUtils.cmake
@@ -1,0 +1,15 @@
+macro(SET_PROJECT_VERSION major minor micro)
+    set(PROJECT_VERSION_MAJOR "${major}")
+    set(PROJECT_VERSION_MINOR "${minor}")
+    set(PROJECT_VERSION_MICRO "${micro}")
+    set(PROJECT_VERSION "${major}.${minor}.${micro}")
+endmacro()
+
+# Libtool library version, not to be confused with API version.
+# See http://www.gnu.org/software/libtool/manual/html_node/Libtool-versioning.html
+macro(CALCULATE_LIBRARY_VERSIONS_FROM_LIBTOOL_TRIPLE library_name current revision age)
+    math(EXPR ${library_name}_VERSION_MAJOR "${current} - ${age}")
+    set(${library_name}_VERSION_MINOR ${age})
+    set(${library_name}_VERSION_MICRO ${revision})
+    set(${library_name}_VERSION ${${library_name}_VERSION_MAJOR}.${age}.${revision})
+endmacro()


### PR DESCRIPTION
This is needed in preparation for the 1.0.0 release.

VersioningUtils.cmake is imported from the WebKit source tree:
https://trac.webkit.org/browser/webkit/trunk/Source/cmake/VersioningUtils.cmake

Fixes #21